### PR TITLE
Build and test without Redis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1360,6 +1360,7 @@ name = "limitador"
 version = "0.1.2"
 dependencies = [
  "async-trait",
+ "cfg-if",
  "criterion",
  "futures",
  "paste",

--- a/README.md
+++ b/README.md
@@ -116,6 +116,10 @@ Then, run the tests:
 cargo test
 ```
 
+or you can run tests disabling the "redis storage" feature:
+```bash
+cd limitador; cargo test --no-default-features
+```
 
 ## License
 

--- a/limitador/Cargo.toml
+++ b/limitador/Cargo.toml
@@ -21,6 +21,7 @@ serde_json = "1.0"
 thiserror = "1.0"
 futures = "0.3"
 async-trait = "0.1.38"
+cfg-if = "0.1"
 
 # Optional dependencies
 redis = { version = "0.17", optional = true }
@@ -30,7 +31,7 @@ serial_test = "0.4"
 criterion = "0.3"
 paste = "0.1"
 rand = "0.7"
-tokio = { version = "0.2", features = ["macros"]} # To be able to use #[tokio::test]
+tokio = { version = "0.2", features = ["rt-core", "macros"] } # To be able to use #[tokio::test]
 
 [[bench]]
 name = "bench"

--- a/limitador/tests/integration_tests.rs
+++ b/limitador/tests/integration_tests.rs
@@ -11,6 +11,7 @@ macro_rules! test_with_all_storage_impls {
                 $function(&mut TestsLimiter::new_from_blocking_impl(rate_limiter)).await;
             }
 
+            #[cfg(feature = "redis_storage")]
             #[tokio::test]
             #[serial]
             async fn [<$function _with_redis>]() {
@@ -31,6 +32,7 @@ macro_rules! test_with_all_storage_impls {
                 $function(&mut TestsLimiter::new_from_blocking_impl(rate_limiter)).await;
             }
 
+            #[cfg(feature = "redis_storage")]
             #[tokio::test]
             #[serial]
             async fn [<$function _with_async_redis>]() {
@@ -51,18 +53,26 @@ mod helpers;
 #[cfg(test)]
 mod test {
     extern crate limitador;
+
+    // To be able to pass the tests without Redis
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "redis_storage")] {
+            use limitador::storage::redis::AsyncRedisStorage;
+            use limitador::storage::redis::RedisStorage;
+
+            use limitador::AsyncRateLimiter;
+            use serial_test::serial;
+            use crate::test::limitador::storage::AsyncStorage;
+            use crate::test::limitador::storage::Storage;
+        }
+    }
+
     use self::limitador::storage::wasm::Clock;
     use self::limitador::RateLimiter;
     use crate::helpers::tests_limiter::*;
-    use crate::test::limitador::storage::AsyncStorage;
-    use crate::test::limitador::storage::Storage;
     use limitador::limit::Limit;
     use limitador::storage::in_memory::InMemoryStorage;
-    use limitador::storage::redis::AsyncRedisStorage;
-    use limitador::storage::redis::RedisStorage;
     use limitador::storage::wasm::WasmStorage;
-    use limitador::AsyncRateLimiter;
-    use serial_test::serial;
     use std::collections::{HashMap, HashSet};
     use std::thread::sleep;
     use std::time::{Duration, SystemTime};


### PR DESCRIPTION
Avoid a hard dependency on redis to be able to build and pass tests