### PR TITLE
Update k8s templates to Limitador-server v0.3.0

### DIFF
--- a/limitador-server/kubernetes/kuard-envoy-config-configmap.yaml
+++ b/limitador-server/kubernetes/kuard-envoy-config-configmap.yaml
@@ -42,14 +42,14 @@ data:
           filter_chains:
             - use_proxy_proto: true
               filters:
-                - name: envoy.http_connection_manager
+                - name: envoy.filters.network.http_connection_manager
                   typed_config:
-                    "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+                    "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
                     use_remote_address: true
                     access_log:
                       - name: envoy.access_loggers.file
                         typed_config:
-                          "@type": type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog
+                          "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
                           path: "/dev/stdout"
                     stat_prefix: http
                     route_config:
@@ -67,11 +67,12 @@ data:
                     http_filters:
                       - name: envoy.filters.http.ratelimit
                         typed_config:
-                          "@type": "type.googleapis.com/envoy.config.filter.http.rate_limit.v2.RateLimit"
+                          "@type": "type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimit"
                           domain: kuard
                           failure_mode_deny: false
                           timeout: 1s
                           rate_limit_service:
+                            transport_api_version: V3
                             grpc_service:
                               { envoy_grpc: { cluster_name: kuard_ratelimit } }
                       - name: envoy.filters.http.router

--- a/limitador-server/kubernetes/limitador-deployment.yaml
+++ b/limitador-server/kubernetes/limitador-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: limitador
-          image: quay.io/3scale/limitador:0.2.0
+          image: quay.io/3scale/limitador:0.3.0
           imagePullPolicy: Always
           env:
             - name: RUST_LOG

--- a/limitador-server/kubernetes/limitador-deployment.yaml
+++ b/limitador-server/kubernetes/limitador-deployment.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
         - name: limitador
           image: quay.io/3scale/limitador:0.3.0
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           env:
             - name: RUST_LOG
               value: info


### PR DESCRIPTION
- Updates limitador-server to 0.3.0
- Updates the Kuard envoy config to use Envoy v3. This is needed because limitador-server 0.3.0 is only compatible with v3 of the rls protocol. While at it, I updated the other filters too (connection manager, and access logs).
- Changed the image pull policy to "IfNotPresent". We needed "Always" before we didn't have stable releases.