### PR TITLE
Github workflow: Run in KinD

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -103,3 +103,15 @@ jobs:
         with:
           command: build
           args: --target=wasm32-unknown-unknown --no-default-features --lib --manifest-path ./limitador/Cargo.toml
+
+  kind:
+    name: Try in kind (Kubernetes in Docker)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: engineerd/setup-kind@v0.5.0
+      - run: |
+          ./limitador-server/script/kind-setup.sh
+          ips=$(kubectl get nodes -lkubernetes.io/hostname!=kind-control-plane -ojsonpath='{.items[*].status.addresses[?(@.type=="InternalIP")].address}')
+          port=$(kubectl -n default get service kuard -ojsonpath='{.spec.ports[?(@.name=="envoy-http")].nodePort}')
+          curl "http://${ips[0]}:${port}"


### PR DESCRIPTION
Adds a new step to the Github Worklow that runs Limitador in KinD. This is useful to check that we didn't break anything in the kubernetes templates.